### PR TITLE
Exclude facebook fbclib param from validation

### DIFF
--- a/foxycart.cart_validation.php
+++ b/foxycart.cart_validation.php
@@ -51,7 +51,7 @@ class FoxyCart_Helper {
      */
     protected static $cart_excludes = array(
         // Analytics values
-        '_', '_ga', '_ke',
+        '_', '_ga', '_ke','fbclid',
         // Cart values
         'cart', 'fcsid', 'empty', 'coupon', 'output', 'sub_token', 'redirect', 'callback', 'locale', 'template_set',
         // Checkout pre-population values


### PR DESCRIPTION
Adding the `fbclib` for exclusion from signing